### PR TITLE
BUG: fix default external links conf value

### DIFF
--- a/pandas_sphinx_theme/theme.conf
+++ b/pandas_sphinx_theme/theme.conf
@@ -6,7 +6,7 @@ pygments_style = tango
 [options]
 sidebarwidth = 270
 sidebar_includehidden = True
-external_links = []
-github_url = ''
-twitter_url = ''
+external_links =
+github_url =
+twitter_url =
 show_prev_next = True


### PR DESCRIPTION
This makes the default entry for external links _empty_ instead of using an empty list `[]`, because the list was being interpreted like a string (`'[', ']'`)

closes #66 
