### PR TITLE
FIx the "edit this page" button link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,7 @@ html_theme_options = {
     ],
     "github_url": "https://github.com/pandas-dev/pandas-sphinx-theme",
     "twitter_url": "https://twitter.com/pandas_dev",
+    "use_edit_page_button": True
 }
 
 html_context = {

--- a/pandas_sphinx_theme/__init__.py
+++ b/pandas_sphinx_theme/__init__.py
@@ -46,8 +46,6 @@ def convert_docutils_node(list_item, only_pages=False):
 
 def update_page_context(self, pagename, templatename, ctx, event_arg):
     from sphinx.environment.adapters.toctree import TocTree
-    self.page_context = ctx
-    self.html_context = self.env.config.html_context
 
     def get_nav_object(**kwds):
         """Return a list of nav links that can be accessed from Jinja."""

--- a/pandas_sphinx_theme/edit_this_page.html
+++ b/pandas_sphinx_theme/edit_this_page.html
@@ -1,7 +1,7 @@
-{% if sourcename is defined and github_user is defined %}
+{% if sourcename is defined and theme_use_edit_page_button==true %}
 {% set src = sourcename.split('.') %}
 <div class="tocsection editthispage">
-    <a href="https://github.com/{{ github_user }}/{{ github_repo }}/edit/{{ github_version }}/{{ doc_path }}/{{ pagename }}.{{ src[-2] }}">
+    <a href="{{ get_edit_url() }}">
         <i class="fas fa-pencil-alt"></i> Edit this page
     </a>
 </div>

--- a/pandas_sphinx_theme/theme.conf
+++ b/pandas_sphinx_theme/theme.conf
@@ -6,6 +6,7 @@ pygments_style = tango
 [options]
 sidebarwidth = 270
 sidebar_includehidden = True
+use_edit_page_button = False
 external_links =
 github_url =
 twitter_url =


### PR DESCRIPTION
This makes a few improvements to our "edit this page" functionality. I decided to do this on the Python side because it'll make the error reporting easier to figure out.

This adds an extra function `get_edit_url` that will return the "edit URL" for a page. Then we use this in the template to make sure it is correct.

I am not sure of the best way to test this so....I haven't added any tests :-)