### PR TITLE
Add option to include Google Analytics

### DIFF
--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -66,3 +66,9 @@ your ``conf.py`` file:
        "github_version": "<your-branch>",
        "doc_path": "<path-from-root-to-your-docs>",
    }
+
+Google Analytics
+================
+
+If the ``google_analytics_id`` config option is specified (like ``UA-XXXXXXX``),
+Google Analytics' javascript is included in the html pages.

--- a/pandas_sphinx_theme/layout.html
+++ b/pandas_sphinx_theme/layout.html
@@ -68,6 +68,19 @@
       </div>
     </div>
     {%- include "scripts.html" %}
+
+    {% if theme_google_analytics_id %}
+    <!-- Google Analytics -->
+    <script>
+      window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+      ga('create', '{{ theme_google_analytics_id }}', 'auto');
+      ga('set', 'anonymizeIp', true);
+      ga('send', 'pageview');
+    </script>
+    <script async src='https://www.google-analytics.com/analytics.js'></script>
+    <!-- End Google Analytics -->
+    {% endif %}
+
 {%- endblock %}
 
 {%- block footer %}

--- a/pandas_sphinx_theme/theme.conf
+++ b/pandas_sphinx_theme/theme.conf
@@ -10,4 +10,5 @@ use_edit_page_button = False
 external_links =
 github_url =
 twitter_url =
+google_analytics_id =
 show_prev_next = True


### PR DESCRIPTION
We were using this for the pandas docs. Going to merge as I want to include it in the pandas docs. 