### PR TITLE
Add pre-commit hook to build:production

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+-   repo: local
+    hooks:
+    -   id: yarn-build-production
+        name: Build src files
+        language: system
+        entry: bash -c "yarn build:production"
+        files: ^src/*

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -41,3 +41,25 @@ the changes in the PR. To access this, click on "Details" of the "build_docs art
 job of Circle CI:
 
 .. image:: _static/pull-request-preview-link.png
+
+
+Ensuring correct commits with pre-commit hooks
+==============================================
+
+To ensure all source files have been correctly build, a `pre-commit <https://pre-commit.com/>`__
+hook is available to use.
+
+To set this up, first install the ``pre-commit`` package::
+
+    # with pip
+    pip install pre-commit
+    # or with conda
+    conda install pre-commit -c conda-forge
+
+and then running from the root of this repo::
+
+    pre-commit install
+
+Now all of the checks will be run each time you commit changes.
+
+Note that if needed, you can skip these checks with ``git commit --no-verify``.


### PR DESCRIPTION
xref https://github.com/pandas-dev/pydata-bootstrap-sphinx-theme/issues/104

This seems to work: tested it out locally with making a change in the scss file, first time committing fails, but also runs build:production, so committing again then passes (similar workflow as I am used with black).

Still need to add some explanation to the contributing guide.