### PR TITLE
DOC: adding docstrings for sphinx monkeypatching / nav objects

### DIFF
--- a/pandas_sphinx_theme/__init__.py
+++ b/pandas_sphinx_theme/__init__.py
@@ -77,13 +77,16 @@ def docutils_node_to_jinja(list_item, only_pages=False):
 def update_page_context(self, pagename, templatename, ctx, event_arg):
     from sphinx.environment.adapters.toctree import TocTree
 
-    def get_nav_object(maxdepth=None, **kwargs):
+    def get_nav_object(maxdepth=None, collapse=True, **kwargs):
         """Return a list of nav links that can be accessed from Jinja.
 
         Parameters
         ----------
         maxdepth: int
             How many layers of TocTree will be returned
+        collapse: bool
+            Whether to only include sub-pages of the currently-active page,
+            instead of sub-pages of all top-level pages of the site.
         kwargs: key/val pairs
             Passed to the `TocTree.get_toctree_for` Sphinx method
         """
@@ -91,7 +94,7 @@ def update_page_context(self, pagename, templatename, ctx, event_arg):
         # "collapse=True" collapses sub-pages of non-active TOC pages.
         # maxdepth controls how many TOC levels are returned
         toctree = TocTree(self.env).get_toctree_for(
-            pagename, self, collapse=True, maxdepth=maxdepth, **kwargs
+            pagename, self, collapse=collapse, maxdepth=maxdepth, **kwargs
         )
 
         # toctree has this structure

--- a/pandas_sphinx_theme/__init__.py
+++ b/pandas_sphinx_theme/__init__.py
@@ -15,52 +15,97 @@ __version__ = "0.0.1.dev0"
 
 
 # -----------------------------------------------------------------------------
-# Sphinx monkeypatch for adding toctree objects into context
+# Sphinx monkeypatch for adding toctree objects into context.
+# This converts the docutils nodes into a nested dictionary that Jinja can
+# use in our templating.
 
 
-def convert_docutils_node(list_item, only_pages=False):
+def docutils_node_to_jinja(list_item, only_pages=False):
+    """Convert a docutils node to a structure that can be read by Jinja.
+
+    Parameters
+    ----------
+    list_item : docutils list_item node
+        A parent item, potentially with children, corresponding to the level
+        of a TocTree.
+    only_pages : bool
+        Only include items for full pages in the output dictionary. Exclude
+        anchor links (TOC items with a URL that starts with #)
+
+    Returns
+    -------
+    nav : dict
+        The TocTree, converted into a dictionary with key/values that work
+        within Jinja.
+    """
     if not list_item.children:
         return None
+
+    # We assume this structure of a list item:
+    # <list_item>
+    #     <compact_paragraph >
+    #         <reference> <-- the thing we want
     reference = list_item.children[0].children[0]
     title = reference.astext()
     url = reference.attributes["refuri"]
     active = "current" in list_item.attributes["classes"]
 
+    # If we've got an anchor link, skip it if we wish
     if only_pages and '#' in url:
         return None
 
+    # Converting the docutils attributes into jinja-friendly objects
     nav = {}
     nav["title"] = title
     nav["url"] = url
-    nav["children"] = []
     nav["active"] = active
 
+    # Recursively convert children as well
+    # If there are sub-pages for this list_item, there should be two children:
+    # a paragraph, and a bullet_list.
+    nav["children"] = []
     if len(list_item.children) > 1:
-        for child_item in list_item.children[1].children:
-            child_nav = convert_docutils_node(child_item, only_pages=only_pages)
+        # The `.children` of the bullet_list has the nodes of the sub-pages.
+        subpage_list = list_item.children[1].children
+        for sub_page in subpage_list:
+            child_nav = docutils_node_to_jinja(sub_page, only_pages=only_pages)
             if child_nav is not None:
                 nav["children"].append(child_nav)
-
     return nav
 
 
 def update_page_context(self, pagename, templatename, ctx, event_arg):
     from sphinx.environment.adapters.toctree import TocTree
 
-    def get_nav_object(**kwds):
-        """Return a list of nav links that can be accessed from Jinja."""
+    def get_nav_object(maxdepth=None, **kwargs):
+        """Return a list of nav links that can be accessed from Jinja.
+
+        Parameters
+        ----------
+        maxdepth: int
+            How many layers of TocTree will be returned
+        kwargs: key/val pairs
+            Passed to the `TocTree.get_toctree_for` Sphinx method
+        """
+        # The TocTree will contain the full site TocTree including sub-pages.
+        # "collapse=True" collapses sub-pages of non-active TOC pages.
+        # maxdepth controls how many TOC levels are returned
         toctree = TocTree(self.env).get_toctree_for(
-            pagename, self, collapse=True, **kwds
+            pagename, self, collapse=True, maxdepth=maxdepth, **kwargs
         )
 
-        # Grab all TOC links from any toctrees on the page
+        # toctree has this structure
+        #   <caption>
+        #   <bullet_list>
+        #       <list_item classes="toctree-l1">
+        #       <list_item classes="toctree-l1">
+        # `list_item`s are the actual TOC links and are the only thing we want
         toc_items = [item for child in toctree.children for item in child
                      if isinstance(item, docutils.nodes.list_item)]
 
-        nav = []
-        for child in toc_items:
-            child_nav = convert_docutils_node(child, only_pages=True)
-            nav.append(child_nav)
+        # Now convert our docutils nodes into dicts that Jinja can use
+        nav = [docutils_node_to_jinja(child, only_pages=True)
+               for child in toc_items]
 
         return nav
 
@@ -69,7 +114,7 @@ def update_page_context(self, pagename, templatename, ctx, event_arg):
         self_toc = TocTree(self.env).get_toc_for(pagename, self)
 
         try:
-            nav = convert_docutils_node(self_toc.children[0])
+            nav = docutils_node_to_jinja(self_toc.children[0])
             return nav
         except:
             return {}

--- a/pandas_sphinx_theme/docs-navbar.html
+++ b/pandas_sphinx_theme/docs-navbar.html
@@ -13,7 +13,7 @@
     <li class="nav-item">
         <a class="nav-link" href="{{ pathto('index') }}">Home</a>
     </li>
-    {% set nav = get_nav_object(maxdepth=1) %}
+    {% set nav = get_nav_object(maxdepth=1, collapse=True) %}
     {% for main_nav_item in nav %}
     <li class="nav-item {% if main_nav_item.active%}active{% endif %}">
         <a class="nav-link" href="{{ main_nav_item.url }}">{{ main_nav_item.title }}</a>

--- a/pandas_sphinx_theme/docs-sidebar.html
+++ b/pandas_sphinx_theme/docs-sidebar.html
@@ -7,7 +7,7 @@
 <nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
 
   <div class="bd-toc-item active">
-  {% set nav = get_nav_object(maxdepth=3) %}
+  {% set nav = get_nav_object(maxdepth=3, collapse=True) %}
 
   <ul class="nav bd-sidenav">
       {% for main_nav_item in nav %}


### PR DESCRIPTION
I was trying to understand what all the monkeypatching code was doing, but was having a really hard time doing so because of the lack of comments and docstrings. This PR doesn't change any behavior, it only adds comments/docstrings, and re-works a little bit of the logic to be easier to read.