### PR TITLE
Add layout blocks

### DIFF
--- a/pandas_sphinx_theme/layout.html
+++ b/pandas_sphinx_theme/layout.html
@@ -38,32 +38,42 @@
   <body data-spy="scroll" data-target="#bd-toc-nav" data-offset="60">
 {%- endblock %}
 {%- block content %}
+    {% block docs_navbar %}
     <nav class="navbar navbar-light navbar-expand-lg bg-light fixed-top bd-navbar" id="navbar-main">
       {%- include "docs-navbar.html" %}
     </nav>
+    {% endblock %}
 
     <div class="container-fluid">
       <div class="row flex-xl-nowrap">
+          {% block docs_sidebar %}
           <div class="col-12 col-md-3 col-xl-2 bd-sidebar">
               {%- include "docs-sidebar.html" %}
           </div>
+          {% endblock %}
 
+          {% block docs_toc %}
           <div class="d-none d-xl-block col-xl-2 bd-toc">
               {% if not (meta is not none and 'notoc' in meta) %}
                 {%- include "docs-toc.html" %}
               {% endif %}
             </div>
+          {% endblock %}
 
+          {% block docs_main %}
           <main class="col-12 col-md-9 col-xl-8 py-md-3 pl-md-5 bd-content" role="main">
+              {% block docs_body %}
               <div>
                 {% block body %} {% endblock %}
               </div>
+              {% endblock %}
               {% if theme_show_prev_next %}
               <div class='prev-next-bottom'>
                 {{ prev_next(prev, next) }}
               </div>
               {% endif %}
           </main>
+          {% endblock %}
 
       </div>
     </div>


### PR DESCRIPTION
This simply puts a block around a few parts of the page layout sections so it could be extended. It shouldn't change any behavior, just means that if a theme extends this one, they can use that block.

(here's the PR where I'm trying to lightly-extend this theme: https://github.com/ExecutableBookProject/cli/pull/7)