### PR TITLE
fixing master doc reference

### DIFF
--- a/pandas_sphinx_theme/docs-navbar.html
+++ b/pandas_sphinx_theme/docs-navbar.html
@@ -1,6 +1,6 @@
 
 {% if logo %}
-<a class="navbar-brand" href="{{ pathto('index') }}">
+<a class="navbar-brand" href="{{ pathto(master_doc) }}">
   <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="logo">
 </a>
 {% endif %}
@@ -11,7 +11,7 @@
 <div id="navbar-menu" class="collapse navbar-collapse">
   <ul id="navbar-main-elements" class="navbar-nav mr-auto">
     <li class="nav-item">
-        <a class="nav-link" href="{{ pathto('index') }}">Home</a>
+        <a class="nav-link" href="{{ pathto(master_doc) }}">Home</a>
     </li>
     {% set nav = get_nav_object(maxdepth=1, collapse=True) %}
     {% for main_nav_item in nav %}


### PR DESCRIPTION
Currently the "home" link is hard-coded to be `index`, but this is a configurable option in Sphinx with `master_doc`. This PR sets the target of the `Home` button to be whatever `master_doc` is.